### PR TITLE
Added option for default voice channel (by name, not id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ Bot.on('ready', () => {
 });
 
 music(Bot, {
-	prefix: '-',     // Prefix of '-'.
-	global: false,   // Server-specific queues.
-	maxQueueSize: 10, // Maximum queue size of 10.
-	clearInvoker: true // If permissions applicable, allow the bot to delete the messages that invoke it (start with prefix)
+	prefix: '-',        // Prefix of '-'.
+	global: false,      // Server-specific queues.
+	maxQueueSize: 10,   // Maximum queue size of 10.
+	clearInvoker: true, // If permissions applicable, allow the bot to delete the messages that invoke it (start with prefix)
+    channel: 'music'    // Name of voice channel to join. If omitted, will instead join user's voice channel.
 });
 Bot.login(token);
 ```
@@ -81,6 +82,7 @@ The module consists of a single function, which takes two arguments:
  * 		anyoneCanSkip: Allow anybody to skip the song.
  * 		clearInvoker: Clear the command message.
  * 		volume: The default volume of the player.
+ *      channel: Name of voice channel to join. If omitted, will instead join user's voice channel.
  */
 music(client, options);
 ```

--- a/examples/musicBot.js
+++ b/examples/musicBot.js
@@ -8,9 +8,10 @@ Bot.on('ready', () => {
 });
 
 music(Bot, {
-	prefix: '-',     // Prefix of '-'.
-	global: false,   // Server-specific queues.
-	maxQueueSize: 10, // Maximum queue size of 10.
-	clearInvoker: true // If permissions applicable, allow the bot to delete the messages that invoke it (start with prefix)
+	prefix: '-',       // Prefix of '-'.
+	global: false,     // Server-specific queues.
+	maxQueueSize: 10,  // Maximum queue size of 10.
+	clearInvoker: true, // If permissions applicable, allow the bot to delete the messages that invoke it (start with prefix)
+    channel: 'music'   // Name of voice channel to join. If omitted, will instead join user's voice channel.
 });
 Bot.login(token);


### PR DESCRIPTION
I have a music channel to limit where the bot can play so I added an optional channel parameter while keeping the original functionality the same if it isn't specified.

I'm not advanced with JS or I would have implemented better error handling if the channel isn't found but I settled for logging the error to the console for now.

I also received a warning about 'sendMessage' being deprecated so I updated all instances to just 'send'.